### PR TITLE
Fix argument passing typo

### DIFF
--- a/ROS/bpl_passthrough/launch/examples/request_joint_positions_udp.launch
+++ b/ROS/bpl_passthrough/launch/examples/request_joint_positions_udp.launch
@@ -9,7 +9,7 @@
     </node>
 
     <node name="request_joints_pos" pkg="bpl_passthrough" type="request_joint_positions.py" output="screen">
-        <param name="frequency" value="$(arg port)"/>
+        <param name="frequency" value="$(arg frequency)"/>
     </node>
 
 </launch>


### PR DESCRIPTION
I noticed you're passing the wrong argument to a parameter (or at least, I think so)