### PR TITLE
Fix(udp_passthrough): get rid of infinite loop to reduce cpu load

### DIFF
--- a/ROS/bpl_passthrough/nodes/udp_passthrough.py
+++ b/ROS/bpl_passthrough/nodes/udp_passthrough.py
@@ -40,7 +40,7 @@ class BPLPassthroughNode:
 
     def rx_receive(self):
         packet_reader = PacketReader()
-        # rate = rospy.Rate(10000)
+        rate = rospy.Rate(10000)
         while not rospy.is_shutdown():
 
             data = bytearray([])
@@ -68,7 +68,7 @@ class BPLPassthroughNode:
                     # rospy.loginfo("Publishing {}".format(ros_packet))
                     self.rx_publisher.publish(ros_packet)
 
-            # rate.sleep()
+            rate.sleep()
             pass
 
 


### PR DESCRIPTION
Uncommented the ros rate in order to get rid of an infinite loop which created an artificially high cpu load.